### PR TITLE
restore delayed.js imports from lib-franklin.js

### DIFF
--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -1,4 +1,5 @@
 // eslint-disable-next-line import/no-cycle
+import { sampleRUM, loadScript } from './lib-franklin.js';
 import { isPerformanceAllowed } from './common.js';
 import {
   DATA_DOMAIN_SCRIPT,


### PR DESCRIPTION
# Fix

The last Update removed too many imports from the `delayed.js` script. This update restores the missing imports needed to run this file.

#

Test URLs:
- Before: https://main--vg-macktrucks-bs--hlxsites.hlx.page/
- After: https://fix-delayed-imports--vg-macktrucks-bs--hlxsites.hlx.page/
